### PR TITLE
Vortex build paul

### DIFF
--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -349,6 +349,7 @@ module-swap gcc/7.3.1: gcc/8.3.1
 setenv OMPI_CXX: ${WORKSPACE}/Trilinos/packages/kokkos/bin/nvcc_wrapper
 setenv OMPI_CC: ${CC}
 setenv OMPI_FC: ${FC}
+setenv TRILINOS_DIR: ${WORKSPACE}/Trilinos
 setenv CUDA_LAUNCH_BLOCKING: 1
 setenv CUDA_MANAGED_FORCE_DEVICE_ALLOC: 1
 setenv PATH_TMP: /projects/atdm_devops/vortex/cmake-3.17.2/bin

--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -343,7 +343,7 @@ unsetenv PATH_TMP:
 
 
 [Trilinos_pullrequest_cuda_10.1.243]
-module-load StdEnv: 
+module-load StdEnv:
 module-load sparc-dev: cuda-10.1.243_gcc-7.3.1_spmpi-rolling
 module-swap gcc/7.3.1: gcc/8.3.1
 setenv OMPI_CXX: ${WORKSPACE}/Trilinos/packages/kokkos/bin/nvcc_wrapper
@@ -352,7 +352,7 @@ setenv OMPI_FC: ${FC}
 setenv CUDA_LAUNCH_BLOCKING: 1
 setenv CUDA_MANAGED_FORCE_DEVICE_ALLOC: 1
 setenv PATH_TMP: /projects/atdm_devops/vortex/cmake-3.17.2/bin
-setenv PATH:     /projects/atdm_devops/vortex/ninja-fortran-1.8.2
+setenv PATH:     /projects/atdm_devops/vortex/ninja-fortran-1.8.2:${PATH_TMP}
 unsetenv PATH_TMP:
 
 

--- a/cmake/std/trilinosprhelpers/setenvironment/ModuleHelper.py
+++ b/cmake/std/trilinosprhelpers/setenvironment/ModuleHelper.py
@@ -24,12 +24,6 @@ else:                                                                           
 
 try:
 
-    # This will force the use of our own module command because the LMOD module
-    # command returns nothing, which won't help us deterine if the command actually
-    # passsed or failed.
-    # TODO: Remove this and clean up the file to just have the module() command.
-    raise ImportError("Force use of _our_ module command for testing")
-
     from env_modules_python import module
     print("NOTICE> [ModuleHelper.py] Using the lmod based `env_modules_python` module handler.")
 

--- a/cmake/std/trilinosprhelpers/setenvironment/ModuleHelper.py
+++ b/cmake/std/trilinosprhelpers/setenvironment/ModuleHelper.py
@@ -24,11 +24,20 @@ else:                                                                           
 
 try:
 
+    # This will force the use of our own module command because the LMOD module
+    # command returns nothing, which won't help us deterine if the command actually
+    # passsed or failed.
+    # TODO: Remove this and clean up the file to just have the module() command.
+    raise ImportError("Force use of _our_ module command for testing")
+
     from env_modules_python import module
+    print("NOTICE> [ModuleHelper.py] Using the lmod based `env_modules_python` module handler.")
 
 except ImportError:
     # If importing module from env_modules_python fails, we roll our own
     # version of that function.
+    print("NOTICE> [ModuleHelper.py] `env_modules_python` not found, using our own `module` command.")
+
 
     def module(*args):
         """
@@ -84,8 +93,11 @@ except ImportError:
             errcode = 1
 
         if errcode:
-            print("module output> {}".format(output))
-            print("module stderr> {}".format(stderr))
+            print("")
+            print("[module output start]\n{}\n[module output end]".format(output))
+            print("[module stderr start]\n{}\n[module stderr end]".format(stderr))
+            print("")
+            sys.stdout.flush()
 
         # Uncomment this if we want to throw an error rather than exit with nonzero code
         #if errcode != 0:

--- a/cmake/std/trilinosprhelpers/setenvironment/ModuleHelper.py
+++ b/cmake/std/trilinosprhelpers/setenvironment/ModuleHelper.py
@@ -6,9 +6,6 @@ This module contains a helper for using the modules subsystem on
 *nix systems.  It will attempt to load the env_modules_python
 module and if that does not exist then we generate our own call
 to the `module()` function.
-
-Todo:
-    Check to find what package provides env_modules_python and document.
 """
 from __future__ import print_function
 
@@ -16,30 +13,72 @@ import os
 import subprocess
 import sys
 
+
 if "MODULESHOME" in os.environ.keys():                                             # pragma: no cover
     sys.path.insert(1, os.path.join(os.environ['MODULESHOME'], 'init'))            # pragma: no cover
 else:                                                                              # pragma: no cover
     print("WARNING: The environment variable 'MODULESHOME' was not found.")        # pragma: no cover
     print("         ModuleHelper may not be able to locate modules.")              # pragma: no cover
 
+
+
 try:
 
-    from env_modules_python import module
+    # Try to import the LMOD version of the module() function.
+    # See: https://github.com/TACC/Lmod/blob/master/init/env_modules_python.py.in
+    import env_modules_python
     print("NOTICE> [ModuleHelper.py] Using the lmod based `env_modules_python` module handler.")
 
+
+    def module(command, *arguments):
+        """
+        `module` wrapper for the LMOD based modules function.
+
+        Args:
+            command (str): The `module` command that we're executing. i.e., `load`, `unload`, `swap`, etc.
+            *arguments   : Variable length argument list.
+
+        Returns:
+            int: status indicating success or failure. 0 = success, nonzero for failure
+
+            For now, because the LMOD `module()` command returns nothing (`NoneType`)
+            and provides no way to determine success or failure, we will only return 0.
+
+        Raises:
+            Any exception thrown by env_modules_python.module() will get caught and passed along.
+
+        """
+        output = 0
+
+        try:
+
+            status = env_modules_python.module(command, *arguments)
+
+        except BaseException as error:
+            print("")
+            print("An ERROR occurred during execution of module command")
+            print("")
+            raise error
+
+        return output
+
+
+
 except ImportError:
-    # If importing module from env_modules_python fails, we roll our own
-    # version of that function.
-    print("NOTICE> [ModuleHelper.py] `env_modules_python` not found, using our own `module` command.")
+    print("NOTICE> [ModuleHelper.py] Using the modulecmd based environment modules handler.")
 
 
-    def module(*args):
+    def module(command, *arguments):
         """
         Function that enables operations on environment modules in
         the system.
 
         Args:
+            command (str): The `module` command that we're executing. i.e., `load`, `unload`, `swap`, etc.
+            *arguments   : Variable length argument list.
 
+        Returns:
+            int: status indicating success or failure.  0 = success, nonzero for failure.
 
         Raises:
             FileNotFoundError: This is thrown if `modulecmd` is not found.
@@ -55,28 +94,37 @@ except ImportError:
         except:
             modulecmd = "/usr/bin/modulecmd"
 
-        if type(args[0]) == type([]):
-            args = args[0]
+        numArgs = len(arguments)
+
+        cmd = [ modulecmd, "python", command ]
+
+        if (numArgs == 1):
+            cmd += arguments[0].split()
         else:
-            args = list(args)
+            cmd += list(arguments)
 
-        cmd = [modulecmd, "python"] + args
-
-        # Execute the command by loading the instructions from
-        # the modulefile and run them.
+        # Execute the `modules` command (i.e., $ module <op> <module name(s)>)
+        # but we don't actually set the environment. If successful, the STDOUT will
+        # contain a sequence of Python commands that we can later execute to set up
+        # the proper environment for the module operation
         proc = subprocess.Popen( cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE )
         (output,stderr) = proc.communicate()
         errcode = proc.returncode
 
         if errcode:
-            print("Failed to execute the module command: {}.".format(" ".join(args)))
+            print("Failed to execute the module command: {}".format(" ".join(cmd[2:])))
             print("- Returned {} exit status.".format(errcode))
         else:
-            exec(output)
+            try:
+                # This is where we _actually_ execute the module command body.
+                exec(output)
+            except BaseException as error:
+                print("An ERROR occurred during execution of module command")
+                raise error
 
         # Convert the bytes into UTF-8 strings
-        output = output.decode('utf-8')
-        stderr = stderr.decode('utf-8')
+        output = output.decode()
+        stderr = stderr.decode()
 
         # Check for success... module tends to return 0 regardless of outcome
         # so we'll have a look at the stderr for indications that there was a

--- a/cmake/std/trilinosprhelpers/setenvironment/ModuleHelper.py
+++ b/cmake/std/trilinosprhelpers/setenvironment/ModuleHelper.py
@@ -91,6 +91,9 @@ except ImportError:
         #if errcode != 0:
         #    raise OSError("Failed to execute module command: {}.".format(" ".join(args)))
 
+        if errcode is None:
+            raise TypeError("ERROR: the errorcode can not be `None`")
+
         return errcode
 
 

--- a/cmake/std/trilinosprhelpers/setenvironment/SetEnvironment.py
+++ b/cmake/std/trilinosprhelpers/setenvironment/SetEnvironment.py
@@ -169,11 +169,14 @@ class SetEnvironment(object):
             params = m[1:]
             cmd_status = 0
             print("[module] module {} {}".format(op, " ".join(params)), end="")
+            module_op_status = -1
             try:
                 if   1 == len(params) and op in ["purge"]:
                     cmd_status = max(ModuleHelper.module(op), status)
                 elif 1 == len(params):
-                    cmd_status = max(ModuleHelper.module(op, params[0]), status)
+                    module_op_status = ModuleHelper.module(op, params[0])
+                    cmd_status = max(module_op_status, status)
+                    #cmd_status = max(ModuleHelper.module(op, params[0]), status)
                 elif 2 == len(params):
                     cmd_status = max(ModuleHelper.module(op, params[0], params[1]), status)
                 else:
@@ -183,6 +186,12 @@ class SetEnvironment(object):
                     raise IndexError(msg)
             except TypeError as err:
                 print(" **INTERNAL ERROR**")
+                print("Debugging Information:")
+                print(":  op               : {}".format(op))
+                print(":  params           : {}".format(params))
+                print(":     len(params)   : {}".format(len(params)))
+                print(":  status           : {}".format(status))
+                print(":  module_op_status : {}".format(module_op_status))
                 sys.stdout.flush()
                 raise(err)
 

--- a/cmake/std/trilinosprhelpers/setenvironment/SetEnvironment.py
+++ b/cmake/std/trilinosprhelpers/setenvironment/SetEnvironment.py
@@ -169,17 +169,22 @@ class SetEnvironment(object):
             params = m[1:]
             cmd_status = 0
             print("[module] module {} {}".format(op, " ".join(params)), end="")
-            if   1 == len(params) and op in ["purge"]:
-                cmd_status = max(ModuleHelper.module(op), status)
-            elif 1 == len(params):
-                cmd_status = max(ModuleHelper.module(op, params[0]), status)
-            elif 2 == len(params):
-                cmd_status = max(ModuleHelper.module(op, params[0], params[1]), status)
-            else:
-                print(" ERROR")
-                msg =  "Invalid number of parameters for `module` command.\n"
-                msg += "- Received {} parameters to a `{}` command.".format(len(params), op)
-                raise IndexError(msg)
+            try:
+                if   1 == len(params) and op in ["purge"]:
+                    cmd_status = max(ModuleHelper.module(op), status)
+                elif 1 == len(params):
+                    cmd_status = max(ModuleHelper.module(op, params[0]), status)
+                elif 2 == len(params):
+                    cmd_status = max(ModuleHelper.module(op, params[0], params[1]), status)
+                else:
+                    print(" ERROR")
+                    msg =  "Invalid number of parameters for `module` command.\n"
+                    msg += "- Received {} parameters to a `{}` command.".format(len(params), op)
+                    raise IndexError(msg)
+            except TypeError as err:
+                print(" **INTERNAL ERROR**")
+                sys.stdout.flush()
+                raise(err)
 
             status = max(cmd_status, status)
 

--- a/cmake/std/trilinosprhelpers/setenvironment/SetEnvironment.py
+++ b/cmake/std/trilinosprhelpers/setenvironment/SetEnvironment.py
@@ -169,14 +169,11 @@ class SetEnvironment(object):
             params = m[1:]
             cmd_status = 0
             print("[module] module {} {}".format(op, " ".join(params)), end="")
-            module_op_status = -1
             try:
                 if   1 == len(params) and op in ["purge"]:
                     cmd_status = max(ModuleHelper.module(op), status)
                 elif 1 == len(params):
-                    module_op_status = ModuleHelper.module(op, params[0])
-                    cmd_status = max(module_op_status, status)
-                    #cmd_status = max(ModuleHelper.module(op, params[0]), status)
+                    cmd_status = max(ModuleHelper.module(op, params[0]), status)
                 elif 2 == len(params):
                     cmd_status = max(ModuleHelper.module(op, params[0], params[1]), status)
                 else:
@@ -191,7 +188,6 @@ class SetEnvironment(object):
                 print(":  params           : {}".format(params))
                 print(":     len(params)   : {}".format(len(params)))
                 print(":  status           : {}".format(status))
-                print(":  module_op_status : {}".format(module_op_status))
                 sys.stdout.flush()
                 raise(err)
 


### PR DESCRIPTION
@prwolfe 
Creating a PR here to track changes for when I get my analysis done on the vortex_build branch errors.

Unfortunately, I cannot log into vortex but I have a PR in.

In the meantime, if you get a chance, can you pop onto Vortex and check the modules and make sure that `StdEnv` is there?

Here's the error message I'm seeing currently with the added error messaging I added in this PR:
```
00:00:58.994 +--------------------------------------------------------------------+
00:00:58.994 |   E N V I R O N M E N T   S E T   U P   S T A R T
00:00:58.994 +--------------------------------------------------------------------+
00:00:58.994 Module Operations
00:00:58.994 +---------------+
00:00:58.994 [module] module load StdEnv **INTERNAL ERROR**
00:00:58.994 Debugging Information:
00:00:58.994 :  op     = load
00:00:58.994 :  params = ['StdEnv']
00:00:58.994 :     len(params) = 1
00:00:58.994 :  status = 0
00:00:58.996 Traceback (most recent call last):
00:00:58.996   File "/vscratch1/trilinos/jenkins/vortex-trilinos/workspace/trilinos-folder/Trilinos_pullrequest_cuda_10.1.243/Trilinos/cmake/std/PullRequestLinuxDriverTest.py", line 259, in <module>
00:00:58.996     status = main(args)
00:00:58.996   File "/vscratch1/trilinos/jenkins/vortex-trilinos/workspace/trilinos-folder/Trilinos_pullrequest_cuda_10.1.243/Trilinos/cmake/std/PullRequestLinuxDriverTest.py", line 249, in main
00:00:58.996     pr_config.prepare_test()
00:00:58.996   File "/vscratch1/trilinos/jenkins/vortex-trilinos/workspace/trilinos-folder/Trilinos_pullrequest_cuda_10.1.243/Trilinos/cmake/std/trilinosprhelpers/TrilinosPRConfigurationBase.py", line 563, in prepare_test
00:00:58.996     rval = tr_config.apply(throw_on_error=True)
00:00:58.996   File "/vscratch1/trilinos/jenkins/vortex-trilinos/workspace/trilinos-folder/Trilinos_pullrequest_cuda_10.1.243/Trilinos/cmake/std/trilinosprhelpers/setenvironment/SetEnvironment.py", line 192, in apply
00:00:58.996     raise(err)
00:00:58.996   File "/vscratch1/trilinos/jenkins/vortex-trilinos/workspace/trilinos-folder/Trilinos_pullrequest_cuda_10.1.243/Trilinos/cmake/std/trilinosprhelpers/setenvironment/SetEnvironment.py", line 176, in apply
00:00:58.996     cmd_status = max(ModuleHelper.module(op, params[0]), status)
00:00:58.996 TypeError: '>' not supported between instances of 'int' and 'NoneType'
00:00:59.015 Build step 'Execute shell' marked build as failure
00:00:59.318 Archiving artifacts
00:00:59.390 [Checks API] No suitable checks publisher found.

00:00:59.733 Finished: FAILURE

```